### PR TITLE
Add yarn start script to call webpack-dev-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@ Minimal Typescript + React + Webpack2 with Hot Module Reloading site
 
 ```
 yarn install
-npm install -g webpack webpack-dev-server
 
-webpack-dev-server
+yarn start
 ```
 
 Building for production

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "webpack-dev-server": "^2.3.0",
     "webpack-hot-middleware": "^2.16.1"
   },
+  "scripts": {
+    "start": "webpack-dev-server"
+  },
   "dependencies": {
     "@types/react": "^15.0.6",
     "@types/react-dom": "^0.14.22",


### PR DESCRIPTION
No need to install global webpack-dev-server if we invoke it from npm/yarn scripts.